### PR TITLE
Add missing align_image_stack to the distribution

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder/
+build-dir/
+local/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
@@ -120,6 +120,11 @@ modules:
       - type: archive
         url: https://github.com/ukoethe/vigra/archive/Version-1-9-0.tar.gz
         sha256: dc041f7ccf838d4321e9bcf522fece1758768dd7a3f8350d1e83e2b8e6daf1e6
+    cleanup:
+      - /bin
+      - /doc
+      - /lib/vigra/
+      - /share
 
   - name: glew
     no-autogen: true
@@ -165,6 +170,11 @@ modules:
       - type: archive
         url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.4/wxWidgets-3.0.4.tar.bz2
         sha256: 96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0
+    cleanup:
+      - /bin
+      - /lib
+      - /doc
+      - /share
 
   - name: libpano13
     buildsystem: cmake
@@ -172,6 +182,9 @@ modules:
       - type: archive
         url: https://downloads.sourceforge.net/project/panotools/libpano13/libpano13-2.9.19/libpano13-2.9.19.tar.gz
         sha256: 037357383978341dea8f572a5d2a0876c5ab0a83dffda431bd393357e91d95a8
+    cleanup:
+      - /bin
+      - /share
 
   - name: align_image_stack
     buildsystem: cmake-ninja
@@ -180,8 +193,32 @@ modules:
       - type: archive
         url: https://downloads.sourceforge.net/project/hugin/hugin/hugin-2018.0/hugin-2018.0.0.tar.bz2
         sha256: d3af0d066ac50e3bb243a175a64ecda136d87178419457e8822e11bcf0e565cb
-      #- type: patch
-        #path: patches/hugin.patch
+    cleanup:
+      - /bin/autooptimiser
+      - /bin/calibrate_lens_gui
+      - /bin/celeste_standalone
+      - /bin/checkpto
+      - /bin/cpclean
+      - /bin/cpfind
+      - /bin/deghosting_mask
+      - /bin/fulla
+      - /bin/geocpset
+      - /bin/hugin*
+      - /bin/icpfind
+      - /bin/linefind
+      - /bin/nona
+      - /bin/pano*
+      - /bin/PT*
+      - /bin/pto_*
+      - /bin/tca_correct
+      - /bin/verdandi
+      - /bin/vig_optimize
+      - /lib/libceleste*
+      - /lib/libhuginbaswwx*
+      - /lib/libicpfindlib*
+      - /lib/liblocalfeatures*
+      - /share
+
 
   - name: luminance
     buildsystem: cmake-ninja

--- a/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
@@ -126,24 +126,8 @@ modules:
       - /lib/vigra/
       - /share
 
-  - name: glew
-    no-autogen: true
-    make-args: &glew-make-args
-      - "GLEW_PREFIX=/app"
-      - "GLEW_DEST=/app"
-      - "LIBDIR=/app/lib"
-    make-install-args: *glew-make-args
-    sources:
-      - type: archive
-        url: https://downloads.sourceforge.net/project/glew/glew/2.1.0/glew-2.1.0.tgz
-        sha256: 04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95
-
-  - name: glu
-    sources:
-      - type: archive
-        url: https://mesa.freedesktop.org/archive/glu/glu-9.0.0.tar.bz2
-        sha256: 1f7ad0d379a722fcbd303aa5650c6d7d5544fde83196b42a73d1193568a4df12
-    cleanup: ["/include", "/lib/*.a", "/lib/*.la", "/lib/pkgconfig"]
+  - shared-modules/glew/glew.json
+  - shared-modules/glu/glu-9.0.0.json
 
   - name: wxWidgets
     cleanup:
@@ -218,7 +202,6 @@ modules:
       - /lib/libicpfindlib*
       - /lib/liblocalfeatures*
       - /share
-
 
   - name: luminance
     buildsystem: cmake-ninja

--- a/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
@@ -109,6 +109,80 @@ modules:
         url: http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3450.tar.gz
         sha256: bf6012dbe668ecb22c399c4b7b2814557ee282c74a7d5dc704eb17c30d9fb92e
 
+  # ==============================
+  # align_image_stack dependencies
+  # ==============================
+  - name: vigra
+    buildsystem: cmake-ninja
+    config-opts:
+       - -DWITH_OPENEXR=ON
+    sources:
+      - type: archive
+        url: https://github.com/ukoethe/vigra/archive/Version-1-9-0.tar.gz
+        sha256: dc041f7ccf838d4321e9bcf522fece1758768dd7a3f8350d1e83e2b8e6daf1e6
+
+  - name: glew
+    no-autogen: true
+    make-args: &glew-make-args
+      - "GLEW_PREFIX=/app"
+      - "GLEW_DEST=/app"
+      - "LIBDIR=/app/lib"
+    make-install-args: *glew-make-args
+    sources:
+      - type: archive
+        url: https://downloads.sourceforge.net/project/glew/glew/2.1.0/glew-2.1.0.tgz
+        sha256: 04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95
+
+  - name: glu
+    sources:
+      - type: archive
+        url: https://mesa.freedesktop.org/archive/glu/glu-9.0.0.tar.bz2
+        sha256: 1f7ad0d379a722fcbd303aa5650c6d7d5544fde83196b42a73d1193568a4df12
+    cleanup: ["/include", "/lib/*.a", "/lib/*.la", "/lib/pkgconfig"]
+
+  - name: wxWidgets
+    cleanup:
+      - /bin
+      - /share/bakefile
+    config-opts:
+      - --with-opengl
+      - --with-libjpeg
+      - --with-libtiff
+      - --with-libpng
+      - --with-zlib
+      - --disable-sdltest
+      - --enable-unicode
+      - --enable-display
+      - --enable-propgrid
+      - --disable-webkit
+      - --disable-webview
+      - --disable-webviewwebkit
+      - --with-expat=builtin
+      - --with-libiconv=/usr
+    build-options:
+      cxxflags: "-std=c++0x"
+    sources:
+      - type: archive
+        url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.4/wxWidgets-3.0.4.tar.bz2
+        sha256: 96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0
+
+  - name: libpano13
+    buildsystem: cmake
+    sources:
+      - type: archive
+        url: https://downloads.sourceforge.net/project/panotools/libpano13/libpano13-2.9.19/libpano13-2.9.19.tar.gz
+        sha256: 037357383978341dea8f572a5d2a0876c5ab0a83dffda431bd393357e91d95a8
+
+  - name: align_image_stack
+    buildsystem: cmake-ninja
+    builddir: true
+    sources:
+      - type: archive
+        url: https://downloads.sourceforge.net/project/hugin/hugin/hugin-2018.0/hugin-2018.0.0.tar.bz2
+        sha256: d3af0d066ac50e3bb243a175a64ecda136d87178419457e8822e11bcf0e565cb
+      #- type: patch
+        #path: patches/hugin.patch
+
   - name: luminance
     buildsystem: cmake-ninja
     sources:

--- a/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
@@ -161,7 +161,8 @@ modules:
       - /share
 
   - name: libpano13
-    buildsystem: cmake
+    buildsystem: cmake-ninja
+    builddir: true
     sources:
       - type: archive
         url: https://downloads.sourceforge.net/project/panotools/libpano13/libpano13-2.9.19/libpano13-2.9.19.tar.gz


### PR DESCRIPTION
Issue ref: https://github.com/LuminanceHDR/LuminanceHDR/issues/140

This one is the attempt to add `align_image_stack` binary to the flathub distribution of LHDR.
While this should work, it needs some polishing and cleaning up and (if possible) optimizations.