### PR TITLE
Update runtime to KDE 5.12

### DIFF
--- a/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
@@ -1,6 +1,6 @@
 app-id: net.sourceforge.qtpfsgui.LuminanceHDR
 runtime: org.kde.Platform
-runtime-version: "5.11"
+runtime-version: "5.12"
 sdk: org.kde.Sdk
 command: luminance-hdr
 rename-icon: luminance-hdr
@@ -106,20 +106,6 @@ modules:
   # ==============================
   # align_image_stack dependencies
   # ==============================
-  - name: vigra
-    buildsystem: cmake-ninja
-    config-opts:
-       - -DWITH_OPENEXR=ON
-    sources:
-      - type: archive
-        url: https://github.com/ukoethe/vigra/archive/Version-1-9-0.tar.gz
-        sha256: dc041f7ccf838d4321e9bcf522fece1758768dd7a3f8350d1e83e2b8e6daf1e6
-    cleanup:
-      - /bin
-      - /doc
-      - /lib/vigra/
-      - /share
-
   - shared-modules/glew/glew.json
   - shared-modules/glu/glu-9.0.0.json
 
@@ -155,7 +141,7 @@ modules:
       - /share
 
   - name: libpano13
-    buildsystem: cmake-ninja
+    buildsystem: cmake # cmake-ninja doesn't work OK with libpano13 and __FILE__ macro in its sources
     builddir: true
     sources:
       - type: archive
@@ -163,6 +149,20 @@ modules:
         sha256: 037357383978341dea8f572a5d2a0876c5ab0a83dffda431bd393357e91d95a8
     cleanup:
       - /bin
+      - /share
+
+  - name: vigra
+    buildsystem: cmake-ninja
+    config-opts:
+       - -DWITH_OPENEXR=ON
+    sources:
+      - type: archive
+        url: https://github.com/ukoethe/vigra/archive/Version-1-11-1.tar.gz
+        sha256: b2718250d28baf1932fcbe8e30f7e4d146e751ad0e726e375a72a0cdb4e3250e
+    cleanup:
+      - /bin
+      - /doc
+      - /lib/vigra/
       - /share
 
   - name: align_image_stack


### PR DESCRIPTION
This commit updates application runtime to org.kde.Platform 5.12. In
order to compile the project, vigra dependency was updated to 1.11.1 amd
libpano13 buildsystem changed to cmake due to bug with cmake-ninja.

Closes #3