### PR TITLE
Prepare to 2.6.0 release

### DIFF
--- a/net.sourceforge.qtpfsgui.LuminanceHDR.appdata.xml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.appdata.xml
@@ -48,8 +48,8 @@
   <url type="donation">https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=10037712</url>
 
   <releases>
-    <release version="2.5.1" date="2017-05-10" />
     <release version="2.6.0" date="2019-06-09" />
+    <release version="2.5.1" date="2017-05-10" />
   </releases>
   <categories>
     <category>Graphics</category>

--- a/net.sourceforge.qtpfsgui.LuminanceHDR.appdata.xml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.appdata.xml
@@ -49,6 +49,7 @@
 
   <releases>
     <release version="2.5.1" date="2017-05-10" />
+    <release version="2.6.0" date="2019-06-09" />
   </releases>
   <categories>
     <category>Graphics</category>

--- a/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
@@ -209,9 +209,9 @@ modules:
   - name: luminance
     buildsystem: cmake-ninja
     sources:
-      - type: git
-        url: https://github.com/LuminanceHDR/LuminanceHDR/
-        commit: 0a68ee751da7fb16c1f83d76d2fc37220bbffc1f
+      - type: archive
+        url: https://github.com/LuminanceHDR/LuminanceHDR/archive/v.2.6.0.tar.gz
+        sha256: c325e0a78a9f2bbfc1af683e09a4eeb412674615a2b17a29f4626962ac3e518c
       - type: file
         path: net.sourceforge.qtpfsgui.LuminanceHDR.appdata.xml
       - type: file

--- a/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
@@ -103,6 +103,14 @@ modules:
         url: http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3450.tar.gz
         sha256: bf6012dbe668ecb22c399c4b7b2814557ee282c74a7d5dc704eb17c30d9fb92e
 
+  - name: eigen3
+    buildsystem: cmake-ninja
+    builddir: true
+    sources:
+      - type: archive
+        url: https://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz
+        sha256: 7e84ef87a07702b54ab3306e77cea474f56a40afa1c0ab245bb11725d006d0da
+
   # ==============================
   # align_image_stack dependencies
   # ==============================
@@ -201,9 +209,9 @@ modules:
   - name: luminance
     buildsystem: cmake-ninja
     sources:
-      - type: archive
-        url: https://github.com/LuminanceHDR/LuminanceHDR/archive/v.2.5.1.tar.gz
-        sha256: 07c02b85a09be1cc4c8940d55a7a2f24c55a071904fedf7c81e621fd0f0ba878
+      - type: git
+        url: https://github.com/LuminanceHDR/LuminanceHDR/
+        commit: 0a68ee751da7fb16c1f83d76d2fc37220bbffc1f
       - type: file
         path: net.sourceforge.qtpfsgui.LuminanceHDR.appdata.xml
       - type: file


### PR DESCRIPTION
Preparing to release LHDR 2.6.0

Currently this PR is work in progress, as there are still no official app release yet. As soon as LHDR is released in its official repo it will be possible to use source archive from release to install LHDR from.