### PR TITLE
Bump libraw to 0.20.2

### DIFF
--- a/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
@@ -82,8 +82,8 @@ modules:
      - --enable-lcms
     sources:
       - type: archive
-        url: https://www.libraw.org/data/LibRaw-0.19.1.tar.gz
-        sha256: a21019db16d87accbb8660056365ab09a204475c77c97b86c922bb972ce15ef6
+        url: https://www.libraw.org/data/LibRaw-0.20.2.tar.gz
+        sha256: dc1b486c2003435733043e4e05273477326e51c3ea554c6864a4eafaff1004a6
     cleanup: [/share/doc]
 
   - name: gsl

--- a/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
@@ -108,8 +108,8 @@ modules:
     builddir: true
     sources:
       - type: archive
-        url: https://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz
-        sha256: 7e84ef87a07702b54ab3306e77cea474f56a40afa1c0ab245bb11725d006d0da
+        url: https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz
+        sha256: d56fbad95abf993f8af608484729e3d87ef611dd85b3380a8bad1d5cbc373a57
 
   # ==============================
   # align_image_stack dependencies


### PR DESCRIPTION
Bumping from 0.19 to 0.20 adds support for a log of new cameras,
including GoPros, Canon CR3 format, multiple new Canon EOS, Nikon,
Olympus and Panasonic models. Full list is at:

https://www.libraw.org/download#changelog