### PR TITLE
update deprecated boost url

### DIFF
--- a/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.yaml
@@ -65,7 +65,7 @@ modules:
       - "./b2 -j $FLATPAK_BUILDER_N_JOBS install"
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2
+        url: https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2
         sha256: f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41
 
   - name: libraw


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
